### PR TITLE
feat: support `payment_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ txref                   | string      |  true            | -             | Uniqu
 amount                  | number      |  true            | -             | Amount to charge.
 integrity_hash          | string      |  false           | -             | (temporarily) This is a sha256 hash of your getpaidSetup values, it is used for passing secured values to the payment gateway.
 payment_method          | string      |  false           | "both"        | This allows you select the payment option you want for your users, possible values are card, account or both.
+payment_options         | string      |  false           | -             | This allows you to select the payment option you want for your users. Possible values are: `'card'`, `'account'`, `'ussd'`. To use more than one option just add them as comma separated values without spaces e.g. `'card,account'`, `'card,account,qr'` etc.
 currency                | string      |  false           | "NGN"         | currency to charge the card in.
 country                 | string      |  false           | "NG"          | route country.
 customer_firstname      | string      |  false           | -             | firstname of the customer.

--- a/projects/angular-rave/src/lib/angular-rave.component.ts
+++ b/projects/angular-rave/src/lib/angular-rave.component.ts
@@ -29,6 +29,7 @@ export class AngularRaveComponent implements OnInit {
   @Input() meta: any;
   @Input() pay_button_text: string;
   @Input() payment_method: string;
+  @Input() payment_options: string;
   @Input() PBFPubKey: string;
   @Input() raveOptions: Partial<PrivateRaveOptions>;
   @Input() redirect_url: string;

--- a/projects/angular-rave/src/lib/angular-rave.directive.ts
+++ b/projects/angular-rave/src/lib/angular-rave.directive.ts
@@ -28,6 +28,7 @@ export class AngularRaveDirective {
   @Input() meta: any;
   @Input() pay_button_text: string;
   @Input() payment_method: string;
+  @Input() payment_options: string;
   @Input() PBFPubKey: string;
   @Input() raveOptions: Partial<PrivateRaveOptions> = {};
   @Input() redirect_url: string;

--- a/projects/angular-rave/src/lib/angular-rave.service.ts
+++ b/projects/angular-rave/src/lib/angular-rave.service.ts
@@ -27,6 +27,7 @@ export class AngularRaveService {
     // raveOptions.hosted_payment = 1; // Modal should open in another page
     raveOptions.PBFPubKey = obj.PBFPubKey || this.PBFPubKey;
     if (obj.payment_method) { raveOptions.payment_method = obj.payment_method; }
+    if (obj.payment_options) { raveOptions.payment_options = obj.payment_options; }
     if (obj.redirect_url) { raveOptions.redirect_url = obj.redirect_url; }
     if (obj.integrity_hash) { raveOptions.integrity_hash = obj.integrity_hash; }
     if (obj.pay_button_text) { raveOptions.pay_button_text = obj.pay_button_text; }

--- a/projects/angular-rave/src/lib/rave-options.ts
+++ b/projects/angular-rave/src/lib/rave-options.ts
@@ -52,6 +52,15 @@ export interface RaveOptions {
    */
   payment_method?: string;
 
+  /**
+   * This allows you to select the payment option you want for your users.
+   * Possible values are: 'card', 'account', 'ussd', 'qr', 'mpesa', 'mobilemoneyghana',
+   * 'mobilemoneyuganda', 'mobilemoneyrwanda', 'mobilemoneyzambia'. 'mobilemoneytanzania',
+   * 'barter', 'bank transfer'.
+   *
+   * To use more than one option just add them as comma separated values without spaces
+   * e.g. 'card,account', 'card,account,qr' etc.
+   */
   payment_options?: string;
   /**
    * Text to be displayed on the Rave Checkout Button

--- a/projects/angular-rave/src/lib/rave-options.ts
+++ b/projects/angular-rave/src/lib/rave-options.ts
@@ -51,6 +51,8 @@ export interface RaveOptions {
    * This allows you select the payment option you want for your users, possible values are card, account or both
    */
   payment_method?: string;
+
+  payment_options?: string;
   /**
    * Text to be displayed on the Rave Checkout Button
    */


### PR DESCRIPTION
Looks like Flutterwave's docs now support `payment_options` vs `payment_method`

https://developer.flutterwave.com/docs/rave-inline#section-rave-inline-parameters

<img width="1279" alt="Screen Shot 2019-12-01 at 8 16 52 PM" src="https://user-images.githubusercontent.com/46732983/69930297-a4657e00-1477-11ea-953e-ce2d072bdfe6.png">
